### PR TITLE
COMMONS-310: Provide method to escape Illegal XPath

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/commons/utils/XPathUtils.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/utils/XPathUtils.java
@@ -18,27 +18,32 @@
 
 package org.exoplatform.commons.utils;
 
+import org.exoplatform.services.jcr.impl.util.ISO9075;
+
 public class XPathUtils {
   
   /**
-   * Avoid the illegal xPath when user name starts with number or user name is an email 
+   * Avoid the illegal xPath 
    * @param path original path
-   * @return Escaped string by converting '@' character and/or the first number of user name to hexa character
+   * @return Escaped string by ISO9075
    */
   public static String escapeIllegalXPathName (String path) {
     if (path == null) return null;
     if (path.length() == 0) return "";
-    StringBuilder buffer = new StringBuilder();
+    StringBuilder encoded = new StringBuilder();
+    StringBuilder currentItem = new StringBuilder();
     for (int i = 0; i < path.length(); i++) {
-      char ch = path.charAt(i);
-      if ((Character.isDigit(ch) && (i == 0 || (i > 0 && path.charAt(i - 1) == '/'))) || ch == '@' ) {
-        buffer.append("_x");
-        buffer.append(String.format("%04x", (int) ch));
-        buffer.append("_");
+      if (path.charAt(i) == '/') {
+        if (currentItem != null && currentItem.length() > 0) {
+          encoded.append(ISO9075.encode(currentItem.toString()));
+          currentItem = new StringBuilder();
+        }
+        encoded.append('/');
       } else {
-      buffer.append(ch);
+        currentItem.append(path.charAt(i));
       }
     }
-    return buffer.toString();
+    if (currentItem != null && currentItem.length() > 0) encoded.append(ISO9075.encode(currentItem.toString()));
+    return encoded.toString();
   }
 }

--- a/commons-component-common/src/main/java/org/exoplatform/commons/utils/XPathUtils.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/utils/XPathUtils.java
@@ -1,0 +1,44 @@
+/***************************************************************************
+ * Copyright (C) 2003-2014 eXo Platform SAS.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see<http://www.gnu.org/licenses/>.
+ *
+ **************************************************************************/
+
+package org.exoplatform.commons.utils;
+
+public class XPathUtils {
+  
+  /**
+   * Avoid the illegal xPath when user name starts with number or user name is an email 
+   * @param path original path
+   * @return Escaped string by converting '@' character and/or the first number of user name to hexa character
+   */
+  public static String escapeIllegalXPathName (String path) {
+    if (path == null) return null;
+    if (path.length() == 0) return "";
+    StringBuilder buffer = new StringBuilder();
+    for (int i = 0; i < path.length(); i++) {
+      char ch = path.charAt(i);
+      if ((Character.isDigit(ch) && (i == 0 || (i > 0 && path.charAt(i - 1) == '/'))) || ch == '@' ) {
+        buffer.append("_x");
+        buffer.append(String.format("%04x", (int) ch));
+        buffer.append("_");
+      } else {
+      buffer.append(ch);
+      }
+    }
+    return buffer.toString();
+  }
+}

--- a/commons-component-common/src/test/java/org/exoplatform/commons/utils/XPathUtilsTest.java
+++ b/commons-component-common/src/test/java/org/exoplatform/commons/utils/XPathUtilsTest.java
@@ -1,0 +1,49 @@
+/***************************************************************************
+ * Copyright (C) 2003-2014 eXo Platform SAS.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see<http://www.gnu.org/licenses/>.
+ *
+ **************************************************************************/
+
+package org.exoplatform.commons.utils;
+
+import org.exoplatform.commons.testing.BaseCommonsTestCase;
+import org.exoplatform.commons.utils.XPathUtils;
+
+public class XPathUtilsTest extends BaseCommonsTestCase {
+
+  public void testNull () {
+    assertNull(XPathUtils.escapeIllegalXPathName(null));
+  }
+  
+  public void testAtSign () {
+    String hexString;
+    hexString = XPathUtils.escapeIllegalXPathName("@testme");
+    assertEquals("At sign is not convertible",hexString,"_x0040_testme");
+    hexString = XPathUtils.escapeIllegalXPathName("/@testme");
+    assertEquals("At sign is not convertible",hexString,"/_x0040_testme");
+    hexString = XPathUtils.escapeIllegalXPathName("/alex.goodman@testme");
+    assertEquals("At sign is not convertible",hexString,"/alex.goodman_x0040_testme");
+  }
+  
+  public void testNumeric() {
+    String hexString;
+    hexString = XPathUtils.escapeIllegalXPathName("123456789");
+    assertEquals("Cannot convert path starting with numberic",hexString ,"_x0031_23456789");
+    hexString = XPathUtils.escapeIllegalXPathName("/123456789");
+    assertEquals("Cannot convert path starting with numberic",hexString ,"/_x0031_23456789");
+    hexString = XPathUtils.escapeIllegalXPathName("/12345/6789");
+    assertEquals("Cannot convert path starting with numberic",hexString ,"/_x0031_2345/_x0036_789");
+  }
+}


### PR DESCRIPTION
Fix description:
    - Escape @ character to support username as email
    - Escape first character if it is numeric to support username as ID
