### PR TITLE
COMMONS-313: Position in Document Selection popup is not relevant

### DIFF
--- a/commons-webui-resources/src/main/webapp/skin/less/DocumentSelector/Style.less
+++ b/commons-webui-resources/src/main/webapp/skin/less/DocumentSelector/Style.less
@@ -43,6 +43,10 @@
 	padding: 3px 10px;
 }
 
+.uiDocumentSelector .listContainer li.selected {
+    font-weight: bold;
+}
+
 .uiDocumentSelector .listContainer a {
 	color: @textColor;
 }


### PR DESCRIPTION
Fix description: Make bold the file label when it is clicked.
