### PR TITLE
COMMONS-320 | [SpaceSwitcher] In spaceSwitcher, it would be better to di...

### DIFF
--- a/commons-webui-component/src/main/java/org/exoplatform/webui/commons/UISpacesSwitcher.java
+++ b/commons-webui-component/src/main/java/org/exoplatform/webui/commons/UISpacesSwitcher.java
@@ -22,7 +22,15 @@ import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.xml.PortalContainerInfo;
 import org.exoplatform.portal.application.PortalRequestContext;
+import org.exoplatform.portal.config.DataStorage;
+import org.exoplatform.portal.config.UserPortalConfig;
+import org.exoplatform.portal.config.UserPortalConfigService;
+import org.exoplatform.portal.config.model.PortalConfig;
+import org.exoplatform.portal.mop.SiteType;
+import org.exoplatform.portal.webui.portal.UIPortal;
 import org.exoplatform.portal.webui.util.Util;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.web.application.Parameter;
 import org.exoplatform.web.application.RequestContext;
@@ -39,6 +47,8 @@ import org.exoplatform.webui.event.EventListener;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
+import javax.servlet.http.HttpServletRequest;
+
 /**
  * Created by The eXo Platform SAS
  * Author : Tran Hung Phong
@@ -51,6 +61,9 @@ import java.util.ResourceBundle;
   events = {@EventConfig(listeners = UISpacesSwitcher.SelectSpaceActionListener.class)}
 )
 public class UISpacesSwitcher extends UIContainer {
+
+  private static final Log LOG = ExoLogger.getLogger("org.exoplatform.webui.commons.UISpacesSwitcher");
+
   public static final String SPACE_ID_PARAMETER = "spaceId";
   
   public static final String SELECT_SPACE_ACTION = "SelectSpace";
@@ -80,6 +93,7 @@ public class UISpacesSwitcher extends UIContainer {
     } else {
       invalidingCacheTime = Long.parseLong(invalidingCacheTimeProperty);
     }
+    initPortalSpaceLabel();
   }
   
   public void init(EventUIComponent eventComponent) {
@@ -95,7 +109,26 @@ public class UISpacesSwitcher extends UIContainer {
   }
   
   public String getCurrentSpaceName() {
-    return currentSpaceName;
+    if  (!StringUtils.isEmpty(portalSpaceLabel)) {
+      PortalRequestContext portalRequestContext = Util.getPortalRequestContext();
+      if (portalRequestContext.getPortalOwner().equalsIgnoreCase(currentSpaceName)) {
+        String spaceId = portalRequestContext.getRequestParameter(SPACE_ID_PARAMETER);
+        if (isCurrentPortalWiki()) {
+          if (StringUtils.isEmpty(spaceId)) {
+            return upperFirstCharacter(portalSpaceLabel);
+          } else {
+            if (spaceId.startsWith("/" + getPortalName())) {
+              return upperFirstCharacter(portalSpaceLabel);
+            }
+          }
+        } else {
+          if (!StringUtils.isEmpty(spaceId) && spaceId.startsWith("/" + getPortalName())) {
+            return upperFirstCharacter(portalSpaceLabel);
+          }
+        }
+      }
+    }
+    return upperFirstCharacter(currentSpaceName);
   }
   
   public String getMySpaceLabel() {
@@ -165,10 +198,60 @@ public class UISpacesSwitcher extends UIContainer {
     PortalContainerInfo containerInfo = (PortalContainerInfo)container.getComponentInstanceOfType(PortalContainerInfo.class);
     return containerInfo.getContainerName();
   }
-  
+
+  public boolean isCurrentPortalWiki() {
+    PortalRequestContext portalRequestContext = Util.getPortalRequestContext();
+    SiteType portalType = portalRequestContext.getSiteType();
+    if (!portalType.equals(SiteType.PORTAL)) {
+      return false;
+    } else {
+      HttpServletRequest request = portalRequestContext.getRequest();
+      String requestURL = request.getRequestURL().toString();
+      UIPortal uiPortal = Util.getUIPortal();
+      String pageNodeSelected = null;
+      try
+      {
+        pageNodeSelected = uiPortal.getSelectedUserNode().getURI();
+      } catch (Exception e)
+      {
+        LOG.error("An error occured while retrieving selected page node: ", e);
+      }
+      if (!requestURL.contains(pageNodeSelected)) {
+        // Happens at the first time processRender() called when add wiki portlet manually
+        requestURL = portalRequestContext.getPortalURI() + pageNodeSelected;
+      }
+      String wikiPageName;
+      if (pageNodeSelected == null) {
+        wikiPageName = "wiki";
+      } else {
+        wikiPageName = pageNodeSelected;
+      }
+      String uri = StringUtils.EMPTY;
+      String sign1 = "/" + wikiPageName + "/";
+      String sign2 = "/" + wikiPageName;
+      if(requestURL.lastIndexOf(sign1) < 0){
+        if(requestURL.lastIndexOf(sign2) > 0) {
+          uri = requestURL.substring(requestURL.lastIndexOf(sign2) + sign2.length()) ;
+        }
+      } else{
+        uri = requestURL.substring(requestURL.lastIndexOf(sign1) + sign1.length()) ;
+      }
+      if(uri != null && uri.length() > 0 && (uri.lastIndexOf("/") + 1) == uri.length())
+        uri = uri.substring(0, uri.lastIndexOf("/")) ;
+
+      if(uri.indexOf("/") > 0) {
+        String[] array = uri.split("/");
+        if (array[0].equals(PortalConfig.USER_TYPE)) {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
+
   public String getPortalSpaceLabel() {
     if (!StringUtils.isEmpty(portalSpaceLabel)) {
-      return portalSpaceLabel;
+      return upperFirstCharacter(portalSpaceLabel);
     }
     PortalRequestContext portalRequestContext = Util.getPortalRequestContext();
     return upperFirstCharacter(portalRequestContext.getPortalOwner());
@@ -177,7 +260,26 @@ public class UISpacesSwitcher extends UIContainer {
   public void setPortalSpaceLabel(String portalSpaceLabel) {
     this.portalSpaceLabel = portalSpaceLabel;
   }
-  
+
+  private void initPortalSpaceLabel() throws Exception {
+    String portalLabel;
+    PortalRequestContext requestContext = Util.getPortalRequestContext();
+    UserPortalConfig userPortalConfig = requestContext.getUserPortalConfig();
+    PortalConfig portalConfig = userPortalConfig.getPortalConfig();
+    if (portalConfig.getType().equals("portal")) {
+      portalLabel = portalConfig.getLabel();
+    } else {
+      String currentPortalName = requestContext.getPortalOwner();
+      UserPortalConfigService userPortalConfigService = getApplicationComponent(UserPortalConfigService.class);
+      DataStorage dataStorage = userPortalConfigService.getDataStorage();
+      portalConfig = dataStorage.getPortalConfig(currentPortalName);
+      portalLabel = portalConfig.getLabel();
+    }
+    if (!StringUtils.isEmpty(portalLabel)) {
+      this.portalSpaceLabel = portalLabel;
+    }
+  }
+
   private String upperFirstCharacter(String str) {
     if (StringUtils.isEmpty(str)) {
       return str;


### PR DESCRIPTION
...splay portalLabel instead of portal name

Fix description:
- Add an `initPortalSpaceLabel()` method  to `UISpaceSwitcher` constructor to initilize the wiki portal space label as it was not set previously.
- Implement new method in `UISpaceSwitcher`; `isCurrentPortalWiki` to check if the current wiki page is the portal one.
- In `org.exoplatform.webui.commons.UISpacesSwitcher#getCurrentSpaceName` in case the **currentSpaceName is same as portalOwner**:
  - If current wiki is portal wiki:
    - Check if _spaceId_ request parameter is empty (this is the case if we navigate to portal wiki portlet), return _portalSpaceLabel_.
    - Else if _spaceId_ is not empty and starts with _/portal_ (e.g: "/portal/intranet") (this is the case when we navigate to portal wiki, then seach some keyword and switch the advanced search space), then return _portalSpaceLabel_.
  - If current wiki is not portal wiki (Enter Wiki Home portlet or a space wiki app):
    - Check if _spaceId_ request parameter is not empty and starts with _/portal_, then return _portalSpaceLabel_.
  - Else return the currentSpaceName.
