### PR TITLE
COMMONS-366: <a target="_blank"> is destroyed by Antisamy

### DIFF
--- a/commons-component-common/src/main/resources/conf/portal/antisamy.xml
+++ b/commons-component-common/src/main/resources/conf/portal/antisamy.xml
@@ -787,7 +787,11 @@ http://www.w3.org/TR/html401/struct/global.html
 				</literal-list>
 			</attribute>
 			<attribute name="name"/>
-			
+			<attribute name="target">
+				<literal-list>
+					<literal value="_blank" />
+				</literal-list>
+			</attribute>
 		</tag>
 
 		<tag name="map" action="validate"/>


### PR DESCRIPTION
Fix description:
- Add target="_blank" as validated condition in a tag