### PR TITLE
COMMONS-378: Product information can't be stored in JCR during upgrade p...

### DIFF
--- a/commons-component-product/src/main/java/org/exoplatform/commons/info/ProductInformations.java
+++ b/commons-component-product/src/main/java/org/exoplatform/commons/info/ProductInformations.java
@@ -38,6 +38,8 @@ import javax.jcr.*;
 import javax.jcr.version.Version;
 import javax.jcr.version.VersionHistory;
 import java.io.*;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -545,10 +547,9 @@ public class ProductInformations implements Startable {
     }
   }
 
-  private static int currentFlag () {
-
-      return Calendar.getInstance(TimeZone.getDefault()).get(Calendar.YEAR);
-
+  private static String currentFlag () {
+    DateFormat dateFormat = new SimpleDateFormat("yyyyMMddHHmmss");
+    return dateFormat.format(Calendar.getInstance(TimeZone.getDefault()).getTime());
   }
 
 }


### PR DESCRIPTION
...rogress

Problem analysis
- Label of version must be unique. However, the version label prefix is only current year. It might lead to label duplication.

Fix description
- Instead of using current year as prefix, use current time to avoid the label duplication
