### PR TITLE
COMMONS-430: [Intranet Notification] NotificationInfo clones without …

### DIFF
--- a/commons-api/src/main/java/org/exoplatform/commons/api/notification/channel/template/PluginTemplateBuilderAdapter.java
+++ b/commons-api/src/main/java/org/exoplatform/commons/api/notification/channel/template/PluginTemplateBuilderAdapter.java
@@ -41,7 +41,7 @@ public class PluginTemplateBuilderAdapter extends AbstractTemplateBuilder {
       AbstractNotificationPlugin abstractPlugin = (AbstractNotificationPlugin) basePlugin;
       return abstractPlugin.buildMessage(ctx);
     }
-    return null;
+    return new MessageInfo().body(ctx.getNotificationInfo().getTitle());
   }
 
   @Override

--- a/commons-api/src/main/java/org/exoplatform/commons/api/notification/model/NotificationInfo.java
+++ b/commons-api/src/main/java/org/exoplatform/commons/api/notification/model/NotificationInfo.java
@@ -451,6 +451,7 @@ public class NotificationInfo {
     NotificationInfo message = instance();
     message.setFrom(from)
            .key(key)
+           .setTitle(title)
            .setOrder(order)
            .setOwnerParameter(new HashMap<String, String>(ownerParameter))
            .setSendToDaily(arrayCopy(sendToDaily))


### PR DESCRIPTION
…Title value

Fix description:
* Set message title in NotificationInfo.clone
* Return a new MessageInfo with only message title when the plugin uses the default TemplateBuilder.