### PR TITLE
COMMONS-451: [Email Notification] Error when sender address is empty

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/commons/notification/NotificationUtils.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/notification/NotificationUtils.java
@@ -218,7 +218,7 @@ public class NotificationUtils {
   }
   
   public static boolean isValidEmailAddresses(String addressList){
-    if (addressList == null || addressList.length() < 0)
+    if (addressList == null || addressList.length() <= 0)
       return false;
     addressList = StringUtils.replace(addressList, ";", ",");
     try {

--- a/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/service/QueueMessageImpl.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/service/QueueMessageImpl.java
@@ -332,6 +332,12 @@ public class QueueMessageImpl extends AbstractService implements QueueMessage, S
       try {
         //ensure the message is valid
         if (message.getFrom() == null) {
+          LOG.debug("Sender address is null.");
+          return false;
+        }
+        // the email address between < and > is empty
+        if (message.getFrom().indexOf("<>") > 0) {
+          LOG.debug("Sender address (" + message.getFrom() + ") is empty.");
           return false;
         }
         mailService.sendMessage(message);

--- a/commons-component-common/src/test/java/org/exoplatform/commons/notification/NotificationUtilsTest.java
+++ b/commons-component-common/src/test/java/org/exoplatform/commons/notification/NotificationUtilsTest.java
@@ -61,7 +61,7 @@ public class NotificationUtilsTest extends TestCase {
   public void testIsValidEmailAddresses() {
     String emails = "";
     // email is empty
-    assertEquals(true, NotificationUtils.isValidEmailAddresses(emails));
+    assertEquals(false, NotificationUtils.isValidEmailAddresses(emails));
     // email only text not @
     emails = "test";
     assertEquals(false, NotificationUtils.isValidEmailAddresses(emails));


### PR DESCRIPTION
Fix description:
- Skip send message when the email address (between < and >) is empty.
