### PR TITLE
COMMONS-552 : make sure PortalContainer has been created before running tests

### DIFF
--- a/commons-component-common/src/test/java/org/exoplatform/commons/persistence/impl/ExoTransactionalAnnotationTest.java
+++ b/commons-component-common/src/test/java/org/exoplatform/commons/persistence/impl/ExoTransactionalAnnotationTest.java
@@ -183,6 +183,9 @@ public class ExoTransactionalAnnotationTest {
 
   @Before
   public void deleteAllTask() {
+    // Make sure the PortalContainer has been created
+    PortalContainer.getInstance();
+
     new TaskDao().deleteAll();
   }
 


### PR DESCRIPTION
The test org.exoplatform.commons.persistence.impl.ExoTransactionalAnnotationTest uses the EntityManagerService which is declared in portal container configuration.
The test class does not explicitly creates the PortalContainer. So if another test class executed before this test class creates the Portal Container (case of local build), the Portal Container is already created and the EntityManagerService is available, and the test passes.
But if no test class creating the PortalContainer is run before this one, the PortalContainer is not created and the EntityManagerService is not instantiated, so the test fails.

The fix makes sure the PortalContainer is created for this test class.