### PR TITLE
PLF-8597 Fix CKEditor instantiation on mobile (#302)

### DIFF
--- a/commons-extension-webapp/src/main/webapp/eXoConfig.js
+++ b/commons-extension-webapp/src/main/webapp/eXoConfig.js
@@ -1,22 +1,31 @@
 ﻿/*
 	eXo config plugins
 */
+// force env when using the eXo Android app (the eXo Android app uses a custom user agent which
+// is not known by CKEditor and which makes it not initialize the editor)
+var userAgent = navigator.userAgent.toLowerCase();
+if(userAgent != null && userAgent.indexOf('exo/') == 0 && userAgent.indexOf('(android)') > 0) {
+  CKEDITOR.env.mobile = true;
+  CKEDITOR.env.chrome = true;
+  CKEDITOR.env.gecko = false;
+  CKEDITOR.env.webkit = true;
+}
 
 CKEDITOR.eXoPath = CKEDITOR.basePath.substr(0, CKEDITOR.basePath.indexOf("ckeditor/"));
 
-// config to add custom plugin	
-(function() {CKEDITOR.plugins.addExternal('content','/eXoWCMResources/eXoPlugins/content/','plugin.js');})();
-(function() {CKEDITOR.plugins.addExternal('insertPortalLink','/commons-extension/eXoPlugins/insertPortalLink/','plugin.js');})();
-(function() {CKEDITOR.plugins.addExternal('simpleLink','/commons-extension/eXoPlugins/simpleLink/','plugin.js');})();
-(function() {CKEDITOR.plugins.addExternal('acceptInline','/eXoWCMResources/eXoPlugins/acceptInline/','plugin.js');})();
-(function() {CKEDITOR.plugins.addExternal('cancelInline','/eXoWCMResources/eXoPlugins/cancelInline/','plugin.js');})();
-(function() {CKEDITOR.plugins.addExternal('helpBBCode','/forum/eXoPlugins/helpBBCode/','plugin.js');})();
-
 CKEDITOR.editorConfig = function( config ){
+  // config to add custom plugin  
+  CKEDITOR.plugins.addExternal('content','/eXoWCMResources/eXoPlugins/content/','plugin.js');
+  CKEDITOR.plugins.addExternal('insertPortalLink','/commons-extension/eXoPlugins/insertPortalLink/','plugin.js');
+  CKEDITOR.plugins.addExternal('simpleLink','/commons-extension/eXoPlugins/simpleLink/','plugin.js');
+  CKEDITOR.plugins.addExternal('acceptInline','/eXoWCMResources/eXoPlugins/acceptInline/','plugin.js');
+  CKEDITOR.plugins.addExternal('cancelInline','/eXoWCMResources/eXoPlugins/cancelInline/','plugin.js');
+  CKEDITOR.plugins.addExternal('helpBBCode','/forum/eXoPlugins/helpBBCode/','plugin.js');
+
 	config.extraPlugins = 'content,insertPortalLink,acceptInline,cancelInline,onchange,helpBBCode,syntaxhighlight';
 	config.removePlugins = 'scayt,wsc';
 	config.toolbarCanCollapse = false;
-	config.skin = 'moono-exo';
+	config.skin = 'moono-exo,/commons-extension/ckeditor/skins/moono-exo/';
 	config.allowedContent = true;
 	config.resize_enabled = true;
 	config.language = eXo.env.portal.language || 'en';
@@ -24,6 +33,9 @@ CKEDITOR.editorConfig = function( config ){
 	config.pasteFromWordRemoveStyles = false;
         config.syntaxhighlight_lang = 'java';
 	config.syntaxhighlight_hideControls = true;
+
+  // style inside the editor
+	config.contentsCss = '/commons-extension/ckeditorCustom/contents.css';
 
 
 	config.toolbar_Default = [

--- a/commons-webui-component/src/main/java/org/exoplatform/webui/form/UIFormRichtextInput.java
+++ b/commons-webui-component/src/main/java/org/exoplatform/webui/form/UIFormRichtextInput.java
@@ -208,8 +208,13 @@ public class UIFormRichtextInput extends UIFormInputBase<String> {
             .append("   CKEDITOR.remove(" + instance + "); " + instance + " = null;\n")
             .append("}\n")
             .append("CKEDITOR.plugins.addExternal('confirmBeforeReload','/commons-extension/eXoPlugins/confirmBeforeReload/','plugin.js');")
-            .append(" CKEDITOR.replace('").append(name).append("', {extraPlugins: 'confirmBeforeReload', toolbar:'").append(toolbar).append("', height:")
-            .append(height).append(", contentsCss:").append(css).append(", enterMode:").append(enterMode)
+            .append("$('[name=\\'").append(name).append("\\']').ckeditor({")
+            .append("customConfig: '/commons-extension/eXoConfig.js',")
+            .append("extraPlugins: 'confirmBeforeReload',")
+            .append("removePlugins: 'hideBottomToolbar',")
+            .append("toolbar:'").append(toolbar).append("',")
+            .append("toolbarLocation: 'top',")
+            .append("height:").append(height).append(", contentsCss:").append(css).append(", enterMode:").append(enterMode)
             .append((isPasteAsPlainText) ? ", forcePasteAsPlainText: true" : "")
             .append(", forceEnterMode:").append(forceEnterMode)
             .append(", shiftEnterMode:").append(shiftEnterMode).append("});\n")
@@ -236,7 +241,7 @@ public class UIFormRichtextInput extends UIFormInputBase<String> {
     //end function   
     jsBuilder.append("}\n");
     jsBuilder.append(functionName + "();\n");
-    context.getJavascriptManager().require("/commons-extension/ckeditor/ckeditor.js").addScripts(jsBuilder.toString());
+    context.getJavascriptManager().require("SHARED/commons-editor", "editor").require("SHARED/jquery", "$").addScripts(jsBuilder.toString());
     //
     return builder.toString();
   }


### PR DESCRIPTION
On mobile, the CKEditor isn't instantiated because of the JS execution order. In fact, if the CKEditor isn't instantiated using require, the code https://github.com/exodev/commons/blob/934618df5bb98cc10be4ff8ad46c16b5f5472754/commons-extension-webapp/src/main/webapp/WEB-INF/gatein-resources.xml#L156 isn't executed, thus the variable `CKEDITOR.env.isCompatible` will remain false. This PR reuse the same way of CKEditor as made for other parts of product such as activity stream.