### PR TITLE
PLF-8447 : Add default to method signature in interface MailNotificationStorage

### DIFF
--- a/commons-api/src/main/java/org/exoplatform/commons/api/notification/service/storage/MailNotificationStorage.java
+++ b/commons-api/src/main/java/org/exoplatform/commons/api/notification/service/storage/MailNotificationStorage.java
@@ -56,6 +56,8 @@ public interface MailNotificationStorage {
    *
    * @throws Exception
    */
-  void deleteAllDigests() throws Exception;
-  
+  default void deleteAllDigests() throws Exception {
+    throw new UnsupportedOperationException();
+  }
+
 }


### PR DESCRIPTION
* Add default to method signature in interface MailNotificationStorage

* throw UnsupportedOperationException in case of using the default implementation