### PR TITLE
PLF-8566: Enable the change of title and subject for Daily and weekly…

### DIFF
--- a/commons-api/pom.xml
+++ b/commons-api/pom.xml
@@ -63,5 +63,10 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/commons-api/src/main/java/org/exoplatform/commons/api/notification/plugin/NotificationPluginUtils.java
+++ b/commons-api/src/main/java/org/exoplatform/commons/api/notification/plugin/NotificationPluginUtils.java
@@ -18,6 +18,7 @@ package org.exoplatform.commons.api.notification.plugin;
 
 import java.util.Locale;
 
+import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.api.settings.SettingService;
 import org.exoplatform.commons.api.settings.SettingValue;
 import org.exoplatform.commons.api.settings.data.Context;
@@ -40,6 +41,8 @@ public class NotificationPluginUtils {
   public static final String NOTIFICATION_SENDER_EMAIL = "exo:notificationSenderEmail";
   
   public static final String BRANDING_PORTAL_NAME = "exo:brandingPortalName";
+  
+  public static final String BRANDING_COMPANY_NAME_SETTING_KEY = "exo.branding.company.name";
 
   public static String getPortalName() {
     return getExoContainerContext().getPortalContainerName();
@@ -124,7 +127,10 @@ public class NotificationPluginUtils {
    */
   public static String getBrandingPortalName() {
     SettingValue<?> name = getSettingService().get(Context.GLOBAL, Scope.GLOBAL.id(null), BRANDING_PORTAL_NAME);
-    return name != null ? (String) name.getValue() : "eXo";
+    if (name == null) {
+      name = getSettingService().get(Context.GLOBAL, Scope.GLOBAL, BRANDING_COMPANY_NAME_SETTING_KEY);
+    }
+    return name != null && StringUtils.isNotBlank((CharSequence) name.getValue()) ? (String) name.getValue() : "eXo";
   }
   
   public static String getTo(String to) {

--- a/commons-api/src/test/java/org/exoplatform/commons/api/notification/plugin/NotificationPluginUtilsTest.java
+++ b/commons-api/src/test/java/org/exoplatform/commons/api/notification/plugin/NotificationPluginUtilsTest.java
@@ -2,12 +2,19 @@ package org.exoplatform.commons.api.notification.plugin;
 
 import junit.framework.TestCase;
 
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.api.settings.SettingValue;
+import org.exoplatform.commons.api.settings.data.Context;
+import org.exoplatform.commons.api.settings.data.Scope;
+import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.UserProfile;
 import org.exoplatform.services.organization.UserProfileHandler;
 import org.exoplatform.services.organization.impl.UserProfileImpl;
-import org.exoplatform.services.resources.LocalePolicy;
+import org.mockito.Mockito;
+
+import static org.exoplatform.commons.api.notification.plugin.NotificationPluginUtils.BRANDING_COMPANY_NAME_SETTING_KEY;
 
 
 /**
@@ -37,5 +44,19 @@ public class NotificationPluginUtilsTest extends TestCase {
 
     language = NotificationPluginUtils.getLanguage(userName);
     assertEquals(langFR_FR, language);
+  }
+
+  public void testGetBrandingPortalName() throws Exception {
+    SettingService settingService = Mockito.mock(SettingService.class);
+    PortalContainer container = PortalContainer.getInstance();
+    container.unregisterComponent(SettingService.class);
+    container.registerComponentInstance(SettingService.class, settingService);
+
+    String companyName = "ACME";
+    SettingValue value = new SettingValue(companyName);
+    Mockito.when(settingService.get(Context.GLOBAL, Scope.GLOBAL, BRANDING_COMPANY_NAME_SETTING_KEY)).thenReturn(value);
+    
+    // Make sure that method getBrandingPortalName returns the changed company name.
+    assertEquals(companyName, NotificationPluginUtils.getBrandingPortalName());
   }
 }


### PR DESCRIPTION
… digest email (#309)

Issue: Title and subject of Daily and weekly digest email is not coherent with company name,
after digging in this issue i found out that the method getBrandingPortalName always returns the default company name which is "eXo".
To fix this issue i made sure to retrieve company name from the company branding storage.