### PR TITLE
PLF-8729 : do not force CKEditor uploaded images alignment on the left (#321)

### DIFF
--- a/commons-extension-webapp/src/main/webapp/eXoPlugins/uploadimage/plugin.js
+++ b/commons-extension-webapp/src/main/webapp/eXoPlugins/uploadimage/plugin.js
@@ -119,7 +119,6 @@
 
 					var img = new CKEDITOR.dom.element( 'img' );
 					img.setAttribute( 'src', loadingImage );
-          img.setAttribute( 'align', "left" );
 					return img;
 				},
 
@@ -137,7 +136,7 @@
 				},
 
 				onUploaded: function( upload ) {
-					this.replaceWith( '<img src="' + upload.url + '" align="left" />' );
+					this.replaceWith( '<img src="' + upload.url + '" />' );
 					if(editor.resizeEditor) {
 					  editor.resizeEditor();
 					} else if(editor.resize) {


### PR DESCRIPTION
When an image is uploaded in CKEditor with the eXo plugin uploadimage, its alignement is forced on the left, even if the current alignement is not.

This fix removes this forced alignement so it can take the current alignement.